### PR TITLE
Mods required for conda pkg, automated builds, and Python 2.7

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -6,7 +6,7 @@ platform:
 
 engine:
   - python=2.7
-  - python=3.3
+  - python=3.4
   - python=3.5
 
 script:

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,17 @@
+package: nbpresent
+user: ijstokes
+
+platform:
+  - linux-64
+
+engine:
+  - python=2.6
+  - python=2.7
+  - python=3.3
+  - python=3.4
+  - python=3.5
+
+script:
+  - conda build -c javascript conda.recipe
+
+build_targets: conda

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -5,10 +5,8 @@ platform:
   - linux-64
 
 engine:
-  - python=2.6
   - python=2.7
   - python=3.3
-  - python=3.4
   - python=3.5
 
 script:

--- a/conda.recipe/.binstar.yml
+++ b/conda.recipe/.binstar.yml
@@ -1,4 +1,0 @@
-package: nbpresent
-script:
-  - conda build . -c javascript
-build_targets: conda

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,10 +11,12 @@ requirements:
     - python
     - notebook
     - jupyter
+    - funcsigs
   run:
     - python
     - notebook
     - jupyter
+    - funcsigs
 
 test:
   imports:

--- a/nbpresent/install.py
+++ b/nbpresent/install.py
@@ -3,7 +3,10 @@
 import argparse
 import os
 from os.path import dirname, abspath, join, exists
-import inspect
+try:
+    from inspect import signature
+except ImportError:
+    from funcsigs import signature
 
 
 def install(enable=False, **kwargs):
@@ -52,7 +55,7 @@ def install(enable=False, **kwargs):
 if __name__ == '__main__':
     from notebook.nbextensions import install_nbextension
 
-    install_kwargs = list(inspect.signature(install_nbextension).parameters)
+    install_kwargs = list(signature(install_nbextension).parameters)
 
     parser = argparse.ArgumentParser(
         description="Installs nbpresent nbextension")


### PR DESCRIPTION
This works for automatically creating conda packages for Python 2.7, 3.4, 3.5.  Does not work with 2.6 and 3.3 since it appears Jupyter Notebook conda packages don't exist for those (and IIRC for 2.6 they never will, and 3.3 I'm not so sure the status).  See:

https://anaconda.org/ijstokes/nbpresent/builds/