### PR TITLE
fixing install switches

### DIFF
--- a/nbpresent/install.py
+++ b/nbpresent/install.py
@@ -28,7 +28,6 @@ def install(enable=False, **kwargs):
     kwargs = {k: v for k, v in kwargs.items() if not (v is None)}
 
     kwargs["destination"] = "nbpresent"
-
     install_nbextension(directory, **kwargs)
 
     if enable:
@@ -64,7 +63,19 @@ if __name__ == '__main__':
         help="Automatically load extension on notebook launch",
         action="store_true")
 
-    [parser.add_argument("--{}".format(arg), action="store", nargs='?')
+    default_kwargs = dict(
+        action="store",
+        nargs="?"
+    )
+
+    store_true_kwargs = dict(action="store_true")
+
+    store_true = ["symlink", "overwrite", "quiet", "user"]
+
+    [parser.add_argument(
+        "--{}".format(arg),
+        **(store_true_kwargs if arg in store_true else default_kwargs)
+        )
         for arg in install_kwargs]
 
     install(**parser.parse_args().__dict__)


### PR DESCRIPTION
The passthrough args to `nbextension install` were completely broken. This adds some more knowledge about the passthrough kwargs based on the current `--help`.

Definitely needs to go into the tests!